### PR TITLE
Fix/ensure stop value is passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function fill(start, stop, step) {
   var result = [],
       iterator = start;
 
-  if (!start && !stop) return "start and stop are required!";
+  if (!start || !stop) return "start and stop are required!";
 
   step = step || 1;
   result = [];
@@ -41,7 +41,7 @@ function fill(start, stop, step) {
 function getObject(start, stop, step) {
   var iterationCount;
 
-  if (!start && !stop) return "start and stop are required!";
+  if (!start || !stop) return "start and stop are required!";
 
   step = step || 1;
 
@@ -64,7 +64,7 @@ function getObject(start, stop, step) {
 function getArray(start, stop, step) {
   var iterationCount;
 
-  if (!start && !stop) return "start and stop are required!";
+  if (!start || !stop) return "start and stop are required!";
 
   step = step || 1;
 

--- a/test/test.js
+++ b/test/test.js
@@ -33,6 +33,12 @@ describe('ranger()', function() {
 
       assert.equal(range, "start and stop are required!");
     });
+
+    it('should return an error if stop is missing', function() {
+      var range = ranger.getArray(1);
+
+      assert.equal(range, "start and stop are required!");
+    });
   });
 
 
@@ -58,6 +64,12 @@ describe('ranger()', function() {
 
       assert.equal(range, "start and stop are required!");
     });
+
+    it('should return an error if stop is missing', function() {
+      var range = ranger.getArray(1);
+
+      assert.equal(range, "start and stop are required!");
+    });
   });
 
 
@@ -80,6 +92,12 @@ describe('ranger()', function() {
 
     it('should return an error if start and stop are missing', function() {
       var range = ranger.fill();
+
+      assert.equal(range, "start and stop are required!");
+    });
+
+    it('should return an error if stop is missing', function() {
+      var range = ranger.fill(1);
 
       assert.equal(range, "start and stop are required!");
     });


### PR DESCRIPTION
Currently, on lines 22, 44 and 67 of `index.js`, the `&&` operator is used instead of the `||` operator. This means that if a user passes in only a start value and no stop value for any of the `ranger.getArray`, `ranger.getObject`, `ranger.fill` methods, the package in its current state will go ahead and try to generate an output and result in a `RangeError: Invalid array length`.

The described issue is fixed by this PR. 😃
